### PR TITLE
Liquid Move hooks, GlobalLiquid, ExampleGlobalLiquid

### DIFF
--- a/ExampleMod/Common/GlobalLiquids/ExampleGlobalLiquid.cs
+++ b/ExampleMod/Common/GlobalLiquids/ExampleGlobalLiquid.cs
@@ -1,0 +1,257 @@
+﻿using ExampleMod.Content.Tiles;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Terraria;
+using Terraria.ModLoader;
+
+namespace ExampleMod.Common.GlobalLiquids
+{
+	//This class prevents liquids from touching or moving past ExampleBlock tiles to show off how the movement of liquids can be controlled with GlobalLiquid.
+	//The hooks can also force liquids to move if desired by returning true in the CanMove hooks, but that isn't shown off here.
+	public class ExampleGlobalLiquid : GlobalLiquid
+	{
+		public override bool? CanMoveLeft(int x, int y, int xMove, int yMove, bool canMoveVanilla) {
+			Tile leftTile = Main.tile[xMove - 1, yMove];
+			int exampleBlock = ModContent.TileType<ExampleBlock>();
+			if (leftTile.TileType == exampleBlock)
+				return false;//Prevents liquids from flowing into a tile touching the right side of an ExampleBlock tile.
+
+			Tile upTile = Main.tile[xMove, yMove - 1];
+			if (upTile.TileType == exampleBlock)
+				return false;//Prevents liquids from flowing into a tile touching the bottom side of an ExampleBlock tile.
+
+			Tile downTile = Main.tile[xMove, yMove + 1];
+			if (downTile.TileType == exampleBlock)
+				return false;//Prevents liquids from flowing into a tile touching the top side of an ExampleBlock tile.
+
+			Tile downLeftTile = Main.tile[xMove - 1, yMove + 1];
+			if (downLeftTile.TileType == exampleBlock)
+				return false;//Prevents liquids from flowing into a tile touching the top right side of an ExampleBlock tile.
+
+			Tile downRightTile = Main.tile[xMove + 1, yMove + 1];
+			if (downRightTile.TileType == exampleBlock)
+				return false;//Prevents liquids from flowing into a tile touching the top left side of an ExampleBlock tile.
+
+			return null;
+		}
+
+		public override bool? CanMoveRight(int x, int y, int xMove, int yMove, bool canMoveVanilla) {
+			Tile rightTile = Main.tile[xMove + 1, yMove];
+			int exampleBlock = ModContent.TileType<ExampleBlock>();
+			if (rightTile.TileType == exampleBlock)
+				return false;//Prevents liquids from flowing into a tile touching the left side of an ExampleBlock tile.
+
+			Tile upTile = Main.tile[xMove, yMove - 1];
+			if (upTile.TileType == exampleBlock)
+				return false;//Prevents liquids from flowing into a tile touching the bottom side of an ExampleBlock tile.
+
+			Tile downTile = Main.tile[xMove, yMove + 1];
+			if (downTile.TileType == exampleBlock)
+				return false;//Prevents liquids from flowing into a tile touching the top side of an ExampleBlock tile.
+
+			Tile downLeftTile = Main.tile[xMove - 1, yMove + 1];
+			if (downLeftTile.TileType == exampleBlock)
+				return false;//Prevents liquids from flowing into a tile touching the top right side of an ExampleBlock tile.
+
+			Tile downRightTile = Main.tile[xMove + 1, yMove + 1];
+			if (downRightTile.TileType == exampleBlock)
+				return false;//Prevents liquids from flowing into a tile touching the top left side of an ExampleBlock tile.
+
+			return null;
+		}
+
+		public override bool? CanMoveDown(int x, int y, int xMove, int yMove, bool canMoveVanilla) {
+			Tile downTile = Main.tile[xMove, yMove + 1];
+			int exampleBlock = ModContent.TileType<ExampleBlock>();
+			if (downTile.TileType == exampleBlock)
+				return false;//Prevents liquids from flowing down onto the top side of an ExampleBlock tile.
+
+			Tile leftTile = Main.tile[xMove - 1, yMove];
+			if (leftTile.TileType == exampleBlock)
+				return false;//Prevents liquids from flowing down into a tile that is touching the right side of an ExampleBlock tile.
+
+			Tile rightTile = Main.tile[xMove + 1, yMove];
+			if (rightTile.TileType == exampleBlock)
+				return false;//Prevents liquids from flowing down into a tile that is touching the left side of an ExampleBlock tile.
+
+			Tile downLeftTile = Main.tile[xMove - 1, yMove + 1];
+			if (downLeftTile.TileType == exampleBlock)
+				return false;//Prevents liquids from flowing down into a tile that is touching the top right side of an ExampleBlock tile.
+
+			Tile downRightTile = Main.tile[xMove + 1, yMove + 1];
+			if (downRightTile.TileType == exampleBlock)
+				return false;//Prevents liquids from flowing down into a tile that is touching the top left side of an ExampleBlock tile.
+
+			return null;
+		}
+
+		public override bool? ShouldDrawLiquids(int x, int y, bool shouldDrawVanilla) {
+			Tile tile = Main.tile[x, y];
+			if (tile.LiquidAmount > 0)
+				return null;
+
+			Tile leftTile = Main.tile[x - 1, y];
+			int exampleBlock = ModContent.TileType<ExampleBlock>();
+			if (leftTile.TileType == exampleBlock)
+				return false;//Prevents liquids from drawing to the right of an ExampleBlock tile.
+
+			Tile rightTile = Main.tile[x + 1, y];
+			if (rightTile.TileType == exampleBlock)
+				return false;//Prevents liquids from drawing to the left of an ExampleBlock tile.
+			
+			Tile downTile = Main.tile[x, y + 1];
+			if (downTile.TileType == exampleBlock)
+				return false;//Prevents liquids from drawing above an ExampleBlock tile.
+
+			Tile upTile = Main.tile[x, y - 1];
+			if (upTile.TileType == exampleBlock)
+				return false;//Prevents liquids from drawing below an ExampleBlock tile.
+
+			Tile upLeftTile = Main.tile[x - 1, y - 1];
+			if (upLeftTile.TileType == exampleBlock)
+				return false;//Prevents liquids from drawing below and to the right of an ExampleBlock tile.
+
+			Tile upRightTile = Main.tile[x + 1, y - 1];
+			if (upRightTile.TileType == exampleBlock)
+				return false;//Prevents liquids from drawing below and to the left of an ExampleBlock tile.
+
+			Tile downRightTile = Main.tile[x + 1, y + 1];
+			if (downRightTile.TileType == exampleBlock)
+				return false;//Prevents liquids from drawing above and to the left of an ExampleBlock tile.
+
+			Tile downLeftTile = Main.tile[x - 1, y + 1];
+			if (downLeftTile.TileType == exampleBlock)
+				return false;//Prevents liquids from drawing above and to the right of an ExampleBlock tile.
+
+			return null;
+		}
+
+		public override bool ShouldMergeLiquids(int x, int y, int thisLiquidType, int mergeLiquidType, int liquidMergeTileType) {
+			//If the liquid has an ExampleBlock on both sides of the body of liquid, prevent merging.
+			int exampleBlock = ModContent.TileType<ExampleBlock>();
+
+			//Move to the farthest connected liquid to the left.
+			int leftX = x - 1;
+			for (; leftX > 0; leftX--) {
+				Tile left = Main.tile[leftX - 1, y];
+				if (left.LiquidAmount <= 0 && left.HasTile)
+					break;
+			}
+
+			//Check if there is an ExampleBlock within 2 blocks of the liquid, or if it's at the edge of the world.
+			if (leftX < 0)
+				return true;
+
+			Tile left1 = Main.tile[leftX, y];
+			if (!left1.HasTile || left1.TileType != exampleBlock) {
+				if (leftX < 1)
+					return true;
+
+				Tile left2 = Main.tile[leftX - 1, y];
+				if (!left2.HasTile || left2.TileType != exampleBlock)
+					return true;
+			}
+
+			//Move to the farthest connected liquid to the right.
+			int rightX = x + 1;
+			for (; rightX < Main.maxTilesX; rightX++) {
+				Tile right = Main.tile[rightX + 1, y];
+				if (right.LiquidAmount <= 0 && right.HasTile)
+					break;
+			}
+
+			//Check if there is an ExampleBlock within 2 blocks of the liquid, or if it's at the edge of the world.
+			if (rightX >= Main.maxTilesX)
+				return true;
+
+			Tile right1 = Main.tile[rightX, y];
+			if (!right1.HasTile || right1.TileType != exampleBlock) {
+				if (rightX >= Main.maxTilesX - 1)
+					return true;
+
+				Tile right2 = Main.tile[rightX + 1, y];
+				if (!right2.HasTile || right2.TileType != exampleBlock)
+					return true;
+			}
+
+			return false;
+		}
+	}
+
+	public class LiquidGlobalTileHelper : GlobalTile {
+		public override void KillTile(int i, int j, int type, ref bool fail, ref bool effectOnly, ref bool noItem) {
+			if (fail || effectOnly)
+				return;
+
+			if (type == ModContent.TileType<ExampleBlock>()) {
+				//AddWater causes the liquid at this location to check if it can flow during the next liquid update.
+				//If this is not done correctly, the liquid won't move when the example block is broken because vanilla only calls AddWater
+				//	for adjacent blocks when they are broken, and ExampleBlock is preventing the liquid from moving from 1 block away.
+				// x u u u x
+				// l x x x r
+				// l x b x r
+				// l x x x r
+				// x d d d x
+
+				//left
+				int leftX2 = i - 2;
+				if (leftX2 >= 0)
+					Liquid.AddWater(leftX2, j);
+
+				//left2 up 1
+				int upY1 = j - 1;
+				if (leftX2 >= 0 && upY1 >= 0)
+					Liquid.AddWater(leftX2, upY1);
+
+				//up2 left 1
+				int upY2 = j - 2;
+				int leftX1 = i - 1;
+				if (leftX1 >= 0 && upY2 >= 0)
+					Liquid.AddWater(leftX2, upY2);
+
+				//up
+				if (upY2 >= 0)
+					Liquid.AddWater(i, upY2);
+
+				//up2 right 1
+				int rightX1 = i + 1;
+				if (rightX1 < Main.maxTilesX && upY2 >= 0)
+					Liquid.AddWater(rightX1, upY2);
+
+				//right2 up 1
+				int rightX2 = i + 2;
+				if (rightX2 < Main.maxTilesX && upY1 >= 0)
+					Liquid.AddWater(rightX2, upY1);
+
+				//right
+				if (rightX2 < Main.maxTilesX)
+					Liquid.AddWater(rightX2, j);
+
+				//right2 down 1
+				int downY1 = j + 1;
+				if (rightX2 < Main.maxTilesX && downY1 < Main.maxTilesY)
+					Liquid.AddWater(rightX2, downY1);
+
+				//down2 right 1
+				int downY2 = j + 2;
+				if (rightX1 < Main.maxTilesX && downY2 < Main.maxTilesY)
+					Liquid.AddWater(rightX1, downY2);
+
+				//down
+				if (downY2 < Main.maxTilesY)
+					Liquid.AddWater(i, downY2);
+
+				//down2 left 1
+				if (leftX1 >= 0 && downY2 < Main.maxTilesY)
+					Liquid.AddWater(leftX1, downY2);
+
+				//left2 down 1
+				if (leftX2 >= 0 && downY1 < Main.maxTilesY)
+					Liquid.AddWater(leftX2, downY1);
+			}
+		}
+	}
+}

--- a/ExampleMod/Common/GlobalLiquids/ExampleGlobalLiquid.cs
+++ b/ExampleMod/Common/GlobalLiquids/ExampleGlobalLiquid.cs
@@ -129,7 +129,13 @@ namespace ExampleMod.Common.GlobalLiquids
 			return null;
 		}
 
-		public override bool ShouldMergeLiquids(int x, int y, int thisLiquidType, int mergeLiquidType, int liquidMergeTileType) {
+		public override bool AllowMergeLiquids(int x, int y, Tile tile, int x2, int y2, Tile tile2) {
+			return ExampleBlockLiquidInteractionsAllowed(x, y);
+		}
+		public override bool ShouldDeleteLiquid(LiquidMerge liquidMerge) {
+			return ExampleBlockLiquidInteractionsAllowed(liquidMerge.X, liquidMerge.Y);
+		}
+		private bool ExampleBlockLiquidInteractionsAllowed(int x, int y) {
 			//If the liquid has an ExampleBlock on both sides of the body of liquid, prevent merging.
 			int exampleBlock = ModContent.TileType<ExampleBlock>();
 

--- a/ExampleMod/Content/Liquids/ExampleLiquid.cs
+++ b/ExampleMod/Content/Liquids/ExampleLiquid.cs
@@ -17,7 +17,7 @@ namespace ExampleMod.Content.Liquids
 			DefaultOpacity = 0.6f;
 		}
 
-		public override void PreUpdate(int x, int y) {
+		public override void PreUpdate(int x, int y, Liquid liquid, Tile thisTile, Tile left, Tile right, Tile up, Tile down) {
 			Tile tile = Main.tile[x, y];
 
 			if (y < 200 && tile.LiquidAmount > 0) {
@@ -29,9 +29,9 @@ namespace ExampleMod.Content.Liquids
 			}
 		}
 
-		public override void Merge(int otherLiquid, bool[] liquidNearby, ref int liquidMergeTileType, ref int liquidMergeType) {
+		public override void GetLiquidMergeTypes(int x, int y, int otherLiquid, bool[] liquidNearby, ref int liquidMergeTileType, ref int liquidMergeType, LiquidMerge liquidMerge) {
 			liquidMergeTileType = 0;
-
+			/*
 			if (otherLiquid == ModContent.GetInstance<ExampleLiquid2>().Type) {
 				liquidMergeTileType = TileID.LunarOre;
 			}
@@ -40,6 +40,7 @@ namespace ExampleMod.Content.Liquids
 			}
 
 			liquidMergeType = 4;
+			*/
 		}
 	}
 }

--- a/patches/tModLoader/Terraria/GameContent/Liquid/LiquidRenderer.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/Liquid/LiquidRenderer.cs.patch
@@ -1,5 +1,13 @@
 --- src/TerrariaNetCore/Terraria/GameContent/Liquid/LiquidRenderer.cs
 +++ src/tModLoader/Terraria/GameContent/Liquid/LiquidRenderer.cs
+@@ -5,6 +_,7 @@
+ using Terraria.Graphics;
+ using Terraria.ID;
+ using Terraria.Utilities;
++using Terraria.ModLoader;
+ 
+ namespace Terraria.GameContent.Liquid;
+ 
 @@ -33,8 +_,8 @@
  		public float VisibleRightWall;
  		public float VisibleBottomWall;
@@ -73,7 +81,7 @@
  
  	public event Action<Color[], Rectangle> WaveFilters;
  
-@@ -131,14 +_,14 @@
+@@ -131,20 +_,24 @@
  		if (_waveMask.Length < drawArea.Width * drawArea.Height)
  			_waveMask = new Color[drawArea.Width * drawArea.Height];
  
@@ -90,3 +98,13 @@
  					if (tile == null)
  						tile = new Tile();
  
+ 					ptr2->LiquidLevel = (float)(int)tile.liquid / 255f;
+ 					ptr2->IsHalfBrick = tile.halfBrick() && ptr2[-1].HasLiquid && !TileID.Sets.Platforms[tile.type];
++					/*
+ 					ptr2->IsSolid = WorldGen.SolidOrSlopedTile(tile);
++					*/
++					bool notSolid = !WorldGen.SolidOrSlopedTile(tile);
++					ptr2->IsSolid = !LiquidLoader.ShouldDrawLiquids(i, j, notSolid);
+ 					ptr2->HasLiquid = tile.liquid != 0;
+ 					ptr2->VisibleLiquidLevel = 0f;
+ 					ptr2->HasWall = tile.wall != 0;

--- a/patches/tModLoader/Terraria/Liquid.cs.patch
+++ b/patches/tModLoader/Terraria/Liquid.cs.patch
@@ -96,7 +96,7 @@
  		byte liquid = tile5.liquid;
  		float num = 0f;
 +
-+		LiquidLoader.PreUpdate(tile5.LiquidType, x, y);
++		LiquidLoader.PreUpdate(x, y, tile5.LiquidType, this, tile5, tile, tile2, tile3, tile4);
 -		if (y > Main.UnderworldLayer && tile5.liquidType() == 0 && tile5.liquid > 0) {
 +		if (y > Main.UnderworldLayer && LiquidLoader.liquidProperties[tile5.liquidType()].HellEvaporation && tile5.liquid > 0) {
  			byte b = 2;
@@ -111,13 +111,13 @@
  		if (tile5.lava()) {
  			LavaCheck(x, y);
  			if (!quickFall) {
-@@ -417,8 +_,50 @@
+@@ -417,8 +_,51 @@
  				}
  			}
  		}
 +		*/
  
-+		for (int i = 0; i < LiquidLoader.LiquidCount; i++) {
++		for (int i = 1; i < LiquidLoader.LiquidCount; i++) {
 +			if (tile5.LiquidType == i) {
 +				if (tile5.LiquidType == LiquidID.Lava) {
 +					LavaCheck(x, y);
@@ -125,6 +125,7 @@
 +				else {
 +					LiquidCheck(x, y, i);
 +				}
++
 +				if (!quickFall) {
 +					if (delay < LiquidLoader.liquidProperties[i].FallDelay) {
 +						delay++;
@@ -135,21 +136,21 @@
 +				}
 +				break;
 +			} else {
-+				if (tile.LiquidType == i)
++				if (tile.LiquidType == i && LiquidLoader.AllowMergeLiquids(x, y, tile5, x - 1, y, tile))
 +					AddWater(x - 1, y);
 +
-+				if (tile2.LiquidType == i)
++				if (tile2.LiquidType == i && LiquidLoader.AllowMergeLiquids(x, y, tile5, x + 1, y, tile2))
 +					AddWater(x + 1, y);
 +
-+				if (tile3.LiquidType == i)
++				if (tile3.LiquidType == i && LiquidLoader.AllowMergeLiquids(x, y, tile5, x, y - 1, tile3))
 +					AddWater(x, y - 1);
 +
-+				if (tile4.LiquidType == i)
++				if (tile4.LiquidType == i && LiquidLoader.AllowMergeLiquids(x, y, tile5, x, y + 1, tile4))
 +					AddWater(x, y + 1);
 +			} 
 +		}
 +
-+		if (!LiquidLoader.Update(tile5.LiquidType, this, x, y, tile, tile2, tile3, tile4)) {
++		if (!LiquidLoader.Update(x, y, tile5.LiquidType, this, tile5, tile, tile2, tile3, tile4)) {
 +			return;
 +		}
 +
@@ -180,18 +181,19 @@
  		}
  
  		if (tile5.liquid != liquid) {
-@@ -744,7 +_,105 @@
+@@ -744,7 +_,106 @@
  		else {
  			kill++;
  		}
 +
++		LiquidLoader.PostUpdate(x, y, tile5.LiquidType, this, tile5, tile, tile2, tile3, tile4);
  	}
 +
 +	//Added by tModLoader
 +	private static bool MovePrevented(Tile tile) => tile.HasUnactuatedTile && Main.tileSolid[tile.TileType] && !Main.tileSolidTop[tile.TileType];
 +
 +	//Added by tModLoader
-+	private static bool WillMerge(Tile tile) => tile.LiquidAmount > 0 && tile.LiquidType != tile.LiquidType;
++	private static bool WillMerge(Tile tile, Tile other) => other.LiquidAmount > 0 && tile.LiquidType != other.LiquidType;
 +
 +	//Added by tModLoader, written by andro951.
 +	//Replaces the code in Update() that moves liquids left and right with loops to make it much easier to work with an insert hooks.
@@ -208,7 +210,7 @@
 +				int leftX = x - i;
 +				Tile tileL = Main.tile[leftX, y];
 +				bool canMoveLeft = true;
-+				if (MovePrevented(tileL) || WillMerge(tileL)) {
++				if (MovePrevented(tileL) || WillMerge(tile, tileL)) {
 +					canMoveLeft = false;
 +				}
 +				else if (i > 1 && tileL.LiquidAmount == 0) {
@@ -226,7 +228,7 @@
 +				int rightX = x + i;
 +				Tile tileR = Main.tile[rightX, y];
 +				bool canMoveRight = true;
-+				if (MovePrevented(tileR) || WillMerge(tileR)) {
++				if (MovePrevented(tileR) || WillMerge(tile, tileR)) {
 +					canMoveRight = false;
 +				}
 +				else if (i > 1 && tileR.LiquidAmount == 0) {
@@ -286,144 +288,494 @@
  
  	public static void StartPanic()
  	{
-@@ -970,6 +_,21 @@
+@@ -963,6 +_,10 @@
+ 		if (WorldGen.SolidTile(x, y))
+ 			return;
+ 
++		LiquidMerge liquidMerge = new(x, y);
++		liquidMerge.TryMerge();
++
++		/*
+ 		Tile tile = Main.tile[x - 1, y];
+ 		Tile tile2 = Main.tile[x + 1, y];
+ 		Tile tile3 = Main.tile[x, y - 1];
+@@ -970,6 +_,7 @@
  		Tile tile5 = Main.tile[x, y];
  		if ((tile.liquid > 0 && tile.liquidType() != thisLiquidType) || (tile2.liquid > 0 && tile2.liquidType() != thisLiquidType) || (tile3.liquid > 0 && tile3.liquidType() != thisLiquidType)) {
  			int num = 0;
 +
-+			bool[] liquidNearby = new bool[LiquidLoader.LiquidCount];
-+
-+			if (tile.LiquidAmount > 0) {
-+				liquidNearby[tile.LiquidType] = true;
-+			}
-+
-+			if (tile2.LiquidAmount > 0) {
-+				liquidNearby[tile2.LiquidType] = true;
-+			}
-+
-+			if (tile3.LiquidAmount > 0) {
-+				liquidNearby[tile3.LiquidType] = true;
-+			}
-+
  			if (tile.liquidType() != thisLiquidType) {
  				num += tile.liquid;
  				tile.liquid = 0;
-@@ -987,11 +_,15 @@
- 
- 			int liquidMergeTileType = 56;
- 			int liquidMergeType = 0;
-+			/*
- 			bool waterNearby = tile.liquidType() == 0 || tile2.liquidType() == 0 || tile3.liquidType() == 0;
+@@ -991,6 +_,7 @@
  			bool lavaNearby = tile.lava() || tile2.lava() || tile3.lava();
  			bool honeyNearby = tile.honey() || tile2.honey() || tile3.honey();
  			bool shimmerNearby = tile.shimmer() || tile2.shimmer() || tile3.shimmer();
-+			*/
 +
--			GetLiquidMergeTypes(thisLiquidType, out liquidMergeTileType, out liquidMergeType, waterNearby, lavaNearby, honeyNearby, shimmerNearby);
-+			// GetLiquidMergeTypes(thisLiquidType, out liquidMergeTileType, out liquidMergeType, waterNearby, lavaNearby, honeyNearby, shimmerNearby);
-+			GetLiquidMergeTypes(thisLiquidType, out liquidMergeTileType, out liquidMergeType, liquidNearby);
+ 			GetLiquidMergeTypes(thisLiquidType, out liquidMergeTileType, out liquidMergeType, waterNearby, lavaNearby, honeyNearby, shimmerNearby);
  			if (num < 24 || liquidMergeType == thisLiquidType)
  				return;
- 
-@@ -1003,6 +_,7 @@
+@@ -1003,6 +_,8 @@
  
  			if (!tile5.active()) {
  				tile5.liquid = 0;
++				*/
 +				/*
  				switch (thisLiquidType) {
  					case 1:
  						tile5.lava(lava: false);
-@@ -1014,6 +_,8 @@
+@@ -1014,6 +_,9 @@
  						tile5.shimmer(shimmer: false);
  						break;
  				}
 +				*/
++				/*
 +				tile5.LiquidType = 0;
  
  				TileChangeType liquidChangeType = WorldGen.GetLiquidChangeType(thisLiquidType, liquidMergeType);
  				if (!WorldGen.gen)
-@@ -1058,12 +_,23 @@
+@@ -1048,6 +_,10 @@
+ 				return;
  
- 			int liquidMergeTileType2 = 56;
- 			int liquidMergeType2 = 0;
-+			/*
- 			bool waterNearby2 = tile4.liquidType() == 0;
+ 			if (tile5.liquid < 24) {
++				//Delete this liquid if it's above a different liquid and liquidAmount is < 24
++				if (!LiquidLoader.ShouldDeleteLiquid(x, y, tile4.LiquidType, thisLiquidType, 56, tile5.LiquidAmount))
++					return;
++
+ 				tile5.liquid = 0;
+ 				tile5.liquidType(0);
+ 				if (Main.netMode == 2)
+@@ -1062,8 +_,11 @@
  			bool lavaNearby2 = tile4.lava();
  			bool honeyNearby2 = tile4.honey();
  			bool shimmerNearby2 = tile4.shimmer();
--			GetLiquidMergeTypes(thisLiquidType, out liquidMergeTileType2, out liquidMergeType2, waterNearby2, lavaNearby2, honeyNearby2, shimmerNearby2);
-+			*/
-+			bool[] liquidNearby = new bool[LiquidLoader.LiquidCount];
-+
-+			if(tile4.LiquidAmount > 0) {
-+				liquidNearby[tile4.LiquidType] = true;
-+			}
 +			
-+
-+			// GetLiquidMergeTypes(thisLiquidType, out liquidMergeTileType, out liquidMergeType, waterNearby, lavaNearby, honeyNearby, shimmerNearby);
-+			GetLiquidMergeTypes(thisLiquidType, out liquidMergeTileType2, out liquidMergeType2, liquidNearby);
+ 			GetLiquidMergeTypes(thisLiquidType, out liquidMergeTileType2, out liquidMergeType2, waterNearby2, lavaNearby2, honeyNearby2, shimmerNearby2);
  			tile5.liquid = 0;
++			*/
 +			/*
  			switch (thisLiquidType) {
  				case 1:
  					tile5.lava(lava: false);
-@@ -1075,6 +_,8 @@
+@@ -1075,6 +_,9 @@
  					tile5.shimmer(shimmer: false);
  					break;
  			}
 +			*/
++			/*
 +			tile5.LiquidType = 0;
  
  			tile4.liquid = 0;
  			TileChangeType liquidChangeType2 = WorldGen.GetLiquidChangeType(thisLiquidType, liquidMergeType2);
-@@ -1088,11 +_,12 @@
+@@ -1086,6 +_,7 @@
+ 			if (Main.netMode == 2)
+ 				NetMessage.SendTileSquare(-1, x - 1, y, 3, liquidChangeType2);
  		}
++		*/
  	}
  
--	public static void GetLiquidMergeTypes(int thisLiquidType, out int liquidMergeTileType, out int liquidMergeType, bool waterNearby, bool lavaNearby, bool honeyNearby, bool shimmerNearby)
-+	//public static void GetLiquidMergeTypes(int thisLiquidType, out int liquidMergeTileType, out int liquidMergeType, bool waterNearby, bool lavaNearby, bool honeyNearby, bool shimmerNearby)
-+	public static void GetLiquidMergeTypes(int thisLiquidType, out int liquidMergeTileType, out int liquidMergeType, bool[] liquidNearby)
- 	{
- 		liquidMergeTileType = 56;
- 		liquidMergeType = thisLiquidType;
--		if (thisLiquidType != 0 && waterNearby) {
-+		if (thisLiquidType != LiquidID.Water && liquidNearby[LiquidID.Water]) {
- 			switch (thisLiquidType) {
- 				case 1:
- 					liquidMergeTileType = 56;
-@@ -1108,7 +_,7 @@
- 			liquidMergeType = 0;
+ 	public static void GetLiquidMergeTypes(int thisLiquidType, out int liquidMergeTileType, out int liquidMergeType, bool waterNearby, bool lavaNearby, bool honeyNearby, bool shimmerNearby)
+@@ -1273,5 +_,403 @@
+ 			else
+ 				WorldGen.CheckLilyPad(num, num2);
  		}
- 
--		if (thisLiquidType != 1 && lavaNearby) {
-+		if (thisLiquidType != LiquidID.Lava && liquidNearby[LiquidID.Lava]) {
- 			switch (thisLiquidType) {
- 				case 0:
- 					liquidMergeTileType = 56;
-@@ -1124,7 +_,7 @@
- 			liquidMergeType = 1;
- 		}
- 
--		if (thisLiquidType != 2 && honeyNearby) {
-+		if (thisLiquidType != LiquidID.Honey && liquidNearby[LiquidID.Honey]) {
- 			switch (thisLiquidType) {
- 				case 0:
- 					liquidMergeTileType = 229;
-@@ -1140,7 +_,7 @@
- 			liquidMergeType = 2;
- 		}
- 
--		if (thisLiquidType != 3 && shimmerNearby) {
-+		if (thisLiquidType != LiquidID.Shimmer && liquidNearby[LiquidID.Shimmer]) {
- 			switch (thisLiquidType) {
- 				case 0:
- 					liquidMergeTileType = 659;
-@@ -1155,6 +_,8 @@
- 
- 			liquidMergeType = 3;
- 		}
++	}
++}
++public abstract class LiquidMergeIngredient
++{
++	public Tile Tile { get; private set; }
++	public int X { get; private set; }
++	public int Y { get; private set; }
++	public abstract byte LiquidAmount { get; }
++	public abstract int LiquidType { get; }
++	public byte LiquidAmountToConsume = 0;
++	internal bool BeingUsedForMerge { get; private set; } = false;
++	internal void SetBeingUsedForMerge()
++	{
++		BeingUsedForMerge = true;
++		LiquidAmountToConsume = LiquidAmount;
++	}
++	internal void CheckBeingUsedForMerge(int x, int y, Tile tile, Tile tile2)
++	{
++		if (LiquidAmount <= 0)
++			return;
 +
-+		LiquidLoader.Merge(thisLiquidType, liquidNearby, ref liquidMergeTileType, ref liquidMergeType);
++		BeingUsedForMerge = LiquidLoader.AllowMergeLiquids(x, y, tile, X, Y, tile2);
++		if (BeingUsedForMerge)
++			LiquidAmountToConsume = LiquidAmount;
++	}
++	internal bool CausingMerge(int liquidType) => BeingUsedForMerge && LiquidType != liquidType;
++	public virtual void DeleteLiquid()
++	{
++		Tile.LiquidAmount = 0;
++		Tile.SetLiquid(LiquidID.Water, true);
++	}
++	public virtual byte ConsumeLiquid()
++	{
++		byte consumedAmount = Math.Min(Tile.LiquidAmount, LiquidAmountToConsume);
++		Tile.LiquidAmount -= consumedAmount;
++		if (Tile.LiquidAmount == 0)
++			Tile.SetLiquid(LiquidID.Water, true);
++
++		return consumedAmount;
++	}
++	public LiquidMergeIngredient(int x, int y)
++	{
++		X = x;
++		Y = y;
++		Tile = Main.tile[x, y];
++	}
++	public LiquidMergeIngredient(int x, int y, int liquidType, byte amount)
++	{
++		X = x;
++		Y = y;
++		Tile = Main.tile[x, y];
++	}
++}
++public class LiquidMergeIngredientTile : LiquidMergeIngredient
++{
++	public override byte LiquidAmount => Tile.LiquidAmount;
++	public override int LiquidType => Tile.LiquidType;
++	public LiquidMergeIngredientTile(int x, int y) : base(x, y) { }
++}
++/// <summary>
++/// Only used in WorldGen.PlaceLiquid()
++/// </summary>
++public class LiquidMergeIngredientBeingPlaced : LiquidMergeIngredient
++{
++	public override byte LiquidAmount => liquidAmount;
++	private byte liquidAmount;
++	public override int LiquidType => liquidType;
++	private int liquidType;
++	public override void DeleteLiquid()
++	{
++		liquidAmount = 0;
++		liquidType = LiquidID.Water;
++	}
++	public override byte ConsumeLiquid()
++	{
++		byte consumedAmount = Math.Min(liquidAmount, LiquidAmountToConsume);
++		liquidAmount -= consumedAmount;
++		if (liquidAmount == 0)
++			liquidType = LiquidID.Water;
++
++		return consumedAmount;
++	}
++	public LiquidMergeIngredientBeingPlaced(int x, int y, int liquidType, byte amount) : base(x, y)
++	{
++		liquidAmount = amount;
++		this.liquidType = liquidType;
++	}
++}
++public class LiquidMerge
++{
++	private enum MergeType
++	{
++		None,
++		TopMerge,
++		BottomMerge,
++		PlaceMerge
++	}
++	/// <summary>
++	/// Controls the sound played when a merge happens.
++	/// </summary>
++	public TileChangeType LiquidChangeType {
++		get {
++			if (!liquidChangeSoundDetermined && LiquidMergeType != LiquidMergeDefaultType) {
++				liquidChangeType = WorldGen.GetLiquidChangeType(ThisLiquidType, LiquidMergeType);
++				liquidChangeSoundDetermined = true;
++			}
++
++			return liquidChangeType;
++		}
++		set {
++			liquidChangeType = value;
++			liquidChangeSoundDetermined = true;
++		}
++	}
++	private TileChangeType liquidChangeType = TileChangeType.None;
++	bool liquidChangeSoundDetermined = false;
++	public int LiquidMergeTileType = LiquidMergeTileDefaultType;
++	private const int LiquidMergeTileDefaultType = -1;
++
++	public int LiquidMergeType = LiquidMergeDefaultType;
++	private const int LiquidMergeDefaultType = -1;
++
++	internal void GetLiquidMergeTypes()
++	{
++		Liquid.GetLiquidMergeTypes(ThisLiquidType, out LiquidMergeTileType, out LiquidMergeType, LiquidsNearby[LiquidID.Water], LiquidsNearby[LiquidID.Lava], LiquidsNearby[LiquidID.Honey], LiquidsNearby[LiquidID.Shimmer]);
++	}
++	public int X { get; private set; }
++	public int Y { get; private set; }
++	internal int ThisLiquidType => thisLiquid.Tile.LiquidType;
++	private LiquidMergeIngredient thisLiquid;
++	private LiquidMergeIngredient leftLiquid;
++	private LiquidMergeIngredient upLiquid;
++	private LiquidMergeIngredient rightLiquid;
++	private LiquidMergeIngredient downLiquid;
++	private Tile ThisTile => thisLiquid.Tile;
++	private Tile LeftTile => leftLiquid.Tile;
++	private Tile UpTile => upLiquid.Tile;
++	private Tile RightTile => rightLiquid.Tile;
++	private Tile DownTile => downLiquid.Tile;
++	public Tile MergeTargetTile { get; private set; }
++	public List<LiquidMergeIngredient> LiquidMergeIngredients { get; private set; } = null;
++	internal bool MergeAllowed => LiquidMergeIngredients != null && LiquidMergeIngredients.Count > 0;
++	private MergeType mergeType = MergeType.None;
++
++	/// <summary>
++	/// Check if a merge will occur and set the MergeTargetTile and LiquidMergeIngredients.
++	/// Shouldn't be called for a PlaceMerge.
++	/// </summary>
++	/// <returns>true if a merge will occur.</returns>
++	private bool DetermineMergeType()
++	{
++		//Check for top merge (Merge onto ThisTile from LeftTile, UpTile or RightTile)
++		leftLiquid.CheckBeingUsedForMerge(X, Y, ThisTile, LeftTile);
++		rightLiquid.CheckBeingUsedForMerge(X, Y, ThisTile, RightTile);
++		upLiquid.CheckBeingUsedForMerge(X, Y, ThisTile, UpTile);
++		bool topMerge = leftLiquid.CausingMerge(ThisLiquidType) || rightLiquid.CausingMerge(ThisLiquidType) || upLiquid.CausingMerge(ThisLiquidType);
++		if (topMerge) {
++			mergeType = MergeType.TopMerge;
++			LiquidMergeIngredients = new();
++			thisLiquid.SetBeingUsedForMerge();
++			LiquidMergeIngredients.Add(thisLiquid);
++
++			if (leftLiquid.BeingUsedForMerge)
++				LiquidMergeIngredients.Add(leftLiquid);
++
++			if (rightLiquid.BeingUsedForMerge)
++				LiquidMergeIngredients.Add(rightLiquid);
++
++			if (upLiquid.BeingUsedForMerge)
++				LiquidMergeIngredients.Add(upLiquid);
++
++			return true;
++		}
++
++		//Check for bottom merge (ThisTile merging onto DownTile)
++		Y = downLiquid.Y;//Bottom merges cause a merge to happen at the DownTile, using ThisTile as an ingredient, so change the target of the merge to the DownTile.
++		thisLiquid.CheckBeingUsedForMerge(X, Y, DownTile, ThisTile);
++		bool bottomMerge = thisLiquid.CausingMerge(downLiquid.LiquidType);
++		if (bottomMerge) {
++			mergeType = MergeType.BottomMerge;
++			LiquidMergeIngredients = new();
++			downLiquid.SetBeingUsedForMerge();
++			LiquidMergeIngredients.Add(downLiquid);
++
++			if (thisLiquid.BeingUsedForMerge)
++				LiquidMergeIngredients.Add(downLiquid);
++
++			return true;
++		}
++
++		return false;
++	}
++	public bool[] LiquidsNearby {
++		get {
++			if (liquidsNearby == null) {
++				UpdateLiquidsNearby();
++			}
++
++			return liquidsNearby;
++		}
++	}
++	private bool[] liquidsNearby = null;
++	public void UpdateLiquidsNearby()
++	{
++		liquidsNearby = new bool[LiquidLoader.LiquidCount];
++		foreach (LiquidMergeIngredient liquidMergeIngredient in LiquidMergeIngredients) {
++			liquidsNearby[liquidMergeIngredient.LiquidType] = true;
++		}
++	}
++	public int[] LiquidsNearbyAmounts {
++		get {
++			if (liquidsNearbyAmount == null) {
++				UpdateLiquidsNearbyAmounts();
++			}
++
++			return liquidsNearbyAmount;
++		}
++	}
++	private int[] liquidsNearbyAmount = null;
++	public void UpdateLiquidsNearbyAmounts()
++	{
++		liquidsNearbyAmount = new int[LiquidLoader.LiquidCount];
++		foreach (LiquidMergeIngredient liquidMergeIngredient in LiquidMergeIngredients) {
++			liquidsNearbyAmount[liquidMergeIngredient.LiquidType] += liquidMergeIngredient.LiquidAmount;
++		}
++	}
++	public void ClearLiquidsNearby()
++	{
++		liquidsNearby = null;
++		liquidsNearbyAmount = null;
++	}
++	public void DeleteLiquids()
++	{
++		for (int i = 1; i < LiquidMergeIngredients.Count; i++) {
++			LiquidMergeIngredient liquidMergeIngredient = LiquidMergeIngredients[i];
++			liquidMergeIngredient.DeleteLiquid();
++		}
++	}
++	public bool MergeTargetTileWillBeDestroyedByMerge => mergeType == MergeType.TopMerge && WillBeDestroyedByObsidianKill || mergeType == MergeType.BottomMerge && (WillBeDestroyedByCut || WillBeDestroyedByObsidianKill);
++	private bool WillBeDestroyedByObsidianKill => MergeTargetTile.HasTile && Main.tileObsidianKill[MergeTargetTile.TileType];
++	private bool WillBeDestroyedByCut => ThisLiquidType != LiquidID.Water && Main.tileCut[MergeTargetTile.TileType];
++	private void TryKillMergeTargetTile()
++	{
++		if (!MergeTargetTileWillBeDestroyedByMerge)
++			return;
++
++		if (mergeType == MergeType.BottomMerge && WillBeDestroyedByCut) {
++			WorldGen.KillTile(X, Y);
++			if (Main.netMode == 2)
++				NetMessage.SendData(17, -1, -1, null, 0, X, Y);
++
++			return;
++		}
++
++		WorldGen.KillTile(X, Y);
++		if (Main.netMode == 2)
++			NetMessage.SendData(17, -1, -1, null, 0, X, Y);
++	}
++	private void PlaceMergeTile()
++	{
++		switch (mergeType) {
++			case MergeType.TopMerge:
++				if (!WorldGen.gen)
++					WorldGen.PlayLiquidChangeSound(liquidChangeType, X, Y);
++
++				WorldGen.PlaceTile(X, Y, LiquidMergeTileType, mute: true, forced: true);
++				WorldGen.SquareTileFrame(X, Y);
++				if (Main.netMode == 2)
++					NetMessage.SendTileSquare(-1, X - 1, Y - 1, 3, liquidChangeType);
++				break;
++			case MergeType.BottomMerge:
++				if (!Main.gameMenu)
++					WorldGen.PlayLiquidChangeSound(liquidChangeType, X, Y - 1);
++
++				WorldGen.PlaceTile(X, Y, LiquidMergeTileType, mute: true, forced: true);
++				WorldGen.SquareTileFrame(X, Y);
++				if (Main.netMode == 2)
++					NetMessage.SendTileSquare(-1, X - 1, Y - 1, 3, liquidChangeType);
++				break;
++			case MergeType.PlaceMerge:
++				WorldGen.PlaceTile(X, Y, LiquidMergeTileType, mute: true);
++				WorldGen.SquareTileFrame(X, Y);
++				if (Main.netMode != 0)
++					NetMessage.SendTileSquare(-1, X - 1, Y - 1, liquidChangeType);
++
++				break;
++		}
++	}
++	public bool Merge(out Dictionary<int, int> consumedLiquids)
++	{
++		TryKillMergeTargetTile();
++		consumedLiquids = new();
++		for (int i = 1; i < LiquidMergeIngredients.Count; i++) {
++			LiquidMergeIngredient liquidMergeIngredient = LiquidMergeIngredients[i];
++			int liquidType = liquidMergeIngredient.LiquidType;
++			int consumedAmount = liquidMergeIngredient.ConsumeLiquid();
++			if (consumedLiquids.ContainsKey(liquidType)) {
++				consumedLiquids[liquidType] += consumedAmount;
++			}
++			else {
++				consumedLiquids.Add(liquidType, consumedAmount);
++			}
++		}
++
++		if (MergeTargetTile.HasTile)
++			return false;
++
++		LiquidMergeIngredient thisLiquidMergeIngredient = LiquidMergeIngredients[0];
++		int thisLiquidType = thisLiquidMergeIngredient.LiquidType;
++		int thisConsumedAmount = thisLiquidMergeIngredient.LiquidAmountToConsume;
++		thisLiquidMergeIngredient.ConsumeLiquid();
++		if (consumedLiquids.ContainsKey(thisLiquidType)) {
++			consumedLiquids[thisLiquidType] += thisConsumedAmount;
++		}
++		else {
++			consumedLiquids.Add(thisLiquidType, thisConsumedAmount);
++		}
++
++		PlaceMergeTile();
++
++		return true;
++	}
++	public void TryMerge()
++	{
++		if (MergeAllowed) {
++			GetLiquidMergeTypes();
++			LiquidLoader.GetLiquidMergeTypes(X, Y, ThisLiquidType, LiquidsNearby, ref LiquidMergeTileType, ref LiquidMergeType, this);
++			int totalOtherLiquids = 0;
++			for (int i = 1; i < LiquidMergeIngredients.Count; i++) {
++				LiquidMergeIngredient liquidMergeIngredient = LiquidMergeIngredients[i];
++				totalOtherLiquids += liquidMergeIngredient.LiquidAmountToConsume;
++			}
++
++			bool deleteLiquids = totalOtherLiquids < 24 || ThisLiquidType == LiquidMergeType;
++			if (deleteLiquids && LiquidLoader.ShouldDeleteLiquid(this)) {
++				DeleteLiquids();
++				return;
++			}
++
++			ClearLiquidsNearby();
++
++			if (LiquidLoader.PreventMerge(this))
++				return;
++
++			ClearLiquidsNearby();
++
++			Merge(out Dictionary<int, int> consumedLiquids);
++			LiquidLoader.OnMerge(this, consumedLiquids);
++		}
++	}
++	internal void TryPlaceMerge()
++	{
++		if (MergeAllowed) {
++			GetLiquidMergeTypes();
++			LiquidLoader.GetLiquidMergeTypes(X, Y, ThisLiquidType, LiquidsNearby, ref LiquidMergeTileType, ref LiquidMergeType, this);
++
++			if (LiquidMergeTileType != 0) {
++				if (LiquidLoader.PreventMerge(this))
++					return;
++
++				ClearLiquidsNearby();
++
++				Merge(out Dictionary<int, int> consumedLiquids);
++				LiquidLoader.OnMerge(this, consumedLiquids);
++			}
++		}
++	}
++	public LiquidMerge(int x, int y)
++	{
++		X = x;
++		Y = y;
++		thisLiquid = new LiquidMergeIngredientTile(x, y);
++		leftLiquid = new LiquidMergeIngredientTile(x - 1, y);
++		rightLiquid = new LiquidMergeIngredientTile(x + 1, y);
++		upLiquid = new LiquidMergeIngredientTile(x, y - 1);
++		downLiquid = new LiquidMergeIngredientTile(x, y + 1);
++		DetermineMergeType();
++	}
++
++	/// <summary>
++	/// Only used in WorldGen.PlaceLiquid(int x, int y, byte liquidType, byte amount)
++	/// </summary>
++	/// <param name="x"></param>
++	/// <param name="y"></param>
++	/// <param name="liquidType"></param>
++	/// <param name="amount"></param>
++	public LiquidMerge(int x, int y, int liquidType, byte amount)
++	{
++		X = x;
++		Y = y;
++		thisLiquid = new LiquidMergeIngredientTile(x, y);
++		LiquidMergeIngredientBeingPlaced liquidBeingPlaced = new(x, y, liquidType, amount);
++		LiquidMergeIngredients = new();
++		thisLiquid.SetBeingUsedForMerge();
++		LiquidMergeIngredients.Add(thisLiquid);
++		liquidBeingPlaced.SetBeingUsedForMerge();
++		LiquidMergeIngredients.Add(liquidBeingPlaced);
++		mergeType = MergeType.PlaceMerge;
  	}
- 
- 	public static void LavaCheck(int x, int y)
+ }

--- a/patches/tModLoader/Terraria/Liquid.cs.patch
+++ b/patches/tModLoader/Terraria/Liquid.cs.patch
@@ -1,14 +1,21 @@
 --- src/TerrariaNetCore/Terraria/Liquid.cs
 +++ src/tModLoader/Terraria/Liquid.cs
-@@ -3,6 +_,7 @@
+@@ -1,10 +_,14 @@
+ using System;
+ using System.Collections.Generic;
++using Terraria;
  using Terraria.GameContent.NetModules;
  using Terraria.ID;
  using Terraria.Localization;
 +using Terraria.ModLoader;
  using Terraria.ObjectData;
  using Terraria.WorldBuilding;
++using Terraria.ModLoader;
++using static Terraria.WorldBuilding.Searches;
  
-@@ -121,7 +_,7 @@
+ namespace Terraria;
+ 
+@@ -121,17 +_,22 @@
  		bool flag = tile.honey();
  		bool flag2 = tile.shimmer();
  		int num3 = tile.liquid;
@@ -17,6 +24,73 @@
  		tile.liquid = 0;
  		bool flag3 = true;
  		while (true) {
+ 			Tile tile2 = Main.tile[num, num2 + 1];
+ 			bool flag4 = false;
++			bool canMoveDownVanilla = num2 < Main.maxTilesY - 5 && tile2.liquid == 0 && (!tile2.nactive() || !Main.tileSolid[tile2.type] || Main.tileSolidTop[tile2.type]);
++			/*
+ 			while (num2 < Main.maxTilesY - 5 && tile2.liquid == 0 && (!tile2.nactive() || !Main.tileSolid[tile2.type] || Main.tileSolidTop[tile2.type])) {
++			*/
++			while (LiquidLoader.CanMoveDown(originX, originY, num, num2 + 1, canMoveDownVanilla)) {
+ 				num2++;
+ 				flag4 = true;
+ 				flag3 = false;
+ 				tile2 = Main.tile[num, num2 + 1];
++				canMoveDownVanilla = num2 < Main.maxTilesY - 5 && tile2.liquid == 0 && (!tile2.nactive() || !Main.tileSolid[tile2.type] || Main.tileSolidTop[tile2.type]);
+ 			}
+ 
+ 			if (WorldGen.gen && flag4 && !flag && !flag2) {
+@@ -149,18 +_,22 @@
+ 			bool flag6 = false;
+ 			bool flag7 = false;
+ 			while (true) {
++				//Left or Right tile Check
+ 				if (Main.tile[num + num5 * num4, num2].liquid == 0) {
+ 					num6 = num4;
+ 					num7 = num5;
+ 				}
+ 
++				//Check if too close to min/max x
+ 				if (num4 == -1 && num + num5 * num4 < 5)
+ 					flag6 = true;
+ 				else if (num4 == 1 && num + num5 * num4 > Main.maxTilesX - 5)
+ 					flag5 = true;
+ 
++				//Check if down tile has the same type of liquid and not full, then transfer liquid to it.
+ 				tile2 = Main.tile[num + num5 * num4, num2 + 1];
+ 				if (tile2.liquid != 0 && tile2.liquid != byte.MaxValue && tile2.liquidType() == b) {
++					//Move liquid to the down tile
+ 					int num8 = 255 - tile2.liquid;
+ 					if (num8 > num3)
+ 						num8 = num3;
+@@ -171,13 +_,28 @@
+ 						break;
+ 				}
+ 
++				//Potential problem here is that the tile being looked at Main.tile[num, num2] is not always the original tile, and won't have values for
++				//	liquid type or liquid, making it difficult to work with.  May need to have a CanSettleLiquids hook with extra info passed in.
++				bool canMoveDown = num2 < Main.maxTilesY - 5 && tile2.liquid == 0 && (!tile2.nactive() || !Main.tileSolid[tile2.type] || Main.tileSolidTop[tile2.type]);
++				int moveX = num + num5 * num4;
++				/*
+ 				if (num2 < Main.maxTilesY - 5 && tile2.liquid == 0 && (!tile2.nactive() || !Main.tileSolid[tile2.type] || Main.tileSolidTop[tile2.type])) {
++				*/
++				if (LiquidLoader.CanMoveDown(moveX, num2, moveX, num2 + 1, canMoveDown)) {
+ 					flag7 = true;
+ 					break;
+ 				}
+ 
++				//Check horizontal tile.
+ 				Tile tile3 = Main.tile[num + (num5 + 1) * num4, num2];
++				bool cantMoveHorizontal = (tile3.liquid != 0 && (!flag3 || num4 != 1)) || (tile3.nactive() && Main.tileSolid[tile3.type] && !Main.tileSolidTop[tile3.type]);
++				bool canMoveHorizontalVanilla = !cantMoveHorizontal;
++				int nextMoveX = num + (num5 + 1) * num4;
++				bool canMoveHorizontal = num4 == -1 ? LiquidLoader.CanMoveLeft(num, num2, nextMoveX, num2, canMoveHorizontalVanilla) : LiquidLoader.CanMoveRight(num, num2, nextMoveX, num2, canMoveHorizontalVanilla);
++				/*
+ 				if ((tile3.liquid != 0 && (!flag3 || num4 != 1)) || (tile3.nactive() && Main.tileSolid[tile3.type] && !Main.tileSolidTop[tile3.type])) {
++				*/
++				if (!canMoveHorizontal) {
+ 					if (num4 == 1)
+ 						flag5 = true;
+ 					else
 @@ -338,7 +_,9 @@
  
  		byte liquid = tile5.liquid;
@@ -37,12 +111,12 @@
  		if (tile5.lava()) {
  			LavaCheck(x, y);
  			if (!quickFall) {
-@@ -417,6 +_,43 @@
+@@ -417,8 +_,50 @@
  				}
  			}
  		}
 +		*/
-+
+ 
 +		for (int i = 0; i < LiquidLoader.LiquidCount; i++) {
 +			if (tile5.LiquidType == i) {
 +				if (tile5.LiquidType == LiquidID.Lava) {
@@ -78,17 +152,140 @@
 +		if (!LiquidLoader.Update(tile5.LiquidType, this, x, y, tile, tile2, tile3, tile4)) {
 +			return;
 +		}
- 
++
++		bool canMoveDown = (!tile4.nactive() || !Main.tileSolid[tile4.type] || Main.tileSolidTop[tile4.type]) && (tile4.liquid <= 0 || tile4.liquidType() == tile5.liquidType()) && tile4.liquid < byte.MaxValue;
++		/*
  		if ((!tile4.nactive() || !Main.tileSolid[tile4.type] || Main.tileSolidTop[tile4.type]) && (tile4.liquid <= 0 || tile4.liquidType() == tile5.liquidType()) && tile4.liquid < byte.MaxValue) {
++		*/
++		if (LiquidLoader.CanMoveDown(x, y, x, y + 1, canMoveDown)) {
++			//Move Down
  			bool flag = false;
-@@ -744,6 +_,7 @@
+ 			num = 255 - tile4.liquid;
+ 			if (num > (float)(int)tile5.liquid)
+@@ -445,6 +_,9 @@
+ 		}
+ 
+ 		if (tile5.liquid > 0) {
++			CheckMoveLiquidsLeftOrRight(x, y);
++
++			/*
+ 			bool flag2 = true;
+ 			bool flag3 = true;
+ 			bool flag4 = true;
+@@ -724,6 +_,7 @@
+ 
+ 				tile5.liquid = (byte)num;
+ 			}
++			*/
+ 		}
+ 
+ 		if (tile5.liquid != liquid) {
+@@ -744,7 +_,105 @@
  		else {
  			kill++;
  		}
-+		
++
  	}
++
++	//Added by tModLoader
++	private static bool MovePrevented(Tile tile) => tile.HasUnactuatedTile && Main.tileSolid[tile.TileType] && !Main.tileSolidTop[tile.TileType];
++
++	//Added by tModLoader
++	private static bool WillMerge(Tile tile) => tile.LiquidAmount > 0 && tile.LiquidType != tile.LiquidType;
++
++	//Added by tModLoader, written by andro951.
++	//Replaces the code in Update() that moves liquids left and right with loops to make it much easier to work with an insert hooks.
++	//Extra care was taken to make the logic exactly the same as the original even where it seems to be inefficient to prevent potential issues.
++	private static void CheckMoveLiquidsLeftOrRight(int x, int y)
++	{
++		Tile tile = Main.tile[x, y];
++		if (tile.LiquidAmount > 0) {
++			float num = 0f;
++			int numLeft = 0;
++			int numRight = 0;
++			int liquidAmount = 0;
++			for (int i = 1; i <= 3; i++) {
++				int leftX = x - i;
++				Tile tileL = Main.tile[leftX, y];
++				bool canMoveLeft = true;
++				if (MovePrevented(tileL) || WillMerge(tileL)) {
++					canMoveLeft = false;
++				}
++				else if (i > 1 && tileL.LiquidAmount == 0) {
++					canMoveLeft = false;
++				}
++				else if (i == 2 && tile.LiquidAmount > 250) {
++					canMoveLeft = false;
++				}
++				
++				if (LiquidLoader.CanMoveLeft(x, y, leftX, y, canMoveLeft)) {
++					numLeft++;
++					liquidAmount += tileL.LiquidAmount;
++				}
++
++				int rightX = x + i;
++				Tile tileR = Main.tile[rightX, y];
++				bool canMoveRight = true;
++				if (MovePrevented(tileR) || WillMerge(tileR)) {
++					canMoveRight = false;
++				}
++				else if (i > 1 && tileR.LiquidAmount == 0) {
++					canMoveRight = false;
++				}
++				else if (i == 2 && tile.LiquidAmount > 250) {
++					canMoveRight = false;
++				}
++				
++				if (LiquidLoader.CanMoveRight(x, y, rightX, y, canMoveRight)) {
++					numRight++;
++					liquidAmount += tileR.LiquidAmount;
++				}
++
++				if (!canMoveLeft || !canMoveRight)
++					break;
++			}
++				
++			num += tile.LiquidAmount + liquidAmount;
++			if (tile.LiquidAmount < 3)
++				num--;
++
++			byte newAmount = (byte)Math.Round(num / (float)(1 + numLeft + numRight));
++			if (newAmount == byte.MaxValue - 1 && WorldGen.genRand.Next(30) == 0)
++				newAmount = byte.MaxValue;
++				
++			bool anyUpdated = false;
++			int higherNum = Math.Max(numLeft, numRight);
++			for (int i = 1; i <= higherNum; i++) {
++				if (i <= numLeft) {
++					int tileX = x - i;
++					Tile tileL = Main.tile[tileX, y];
++					tileL.LiquidType = tile.LiquidType;
++					if (tileL.LiquidAmount != newAmount || tile.LiquidAmount != newAmount) {
++						tileL.LiquidAmount = newAmount;
++						Liquid.AddWater(tileX, y);
++						anyUpdated = true;
++					}
++				}
++	
++				if (i <= numRight) {
++					int tileX = x + i;
++					Tile tileLR = Main.tile[tileX, y];
++					tileLR.LiquidType = tile.LiquidType;
++					if (tileLR.LiquidAmount != newAmount || tile.LiquidAmount != newAmount) {
++						tileLR.LiquidAmount = newAmount;
++						Liquid.AddWater(tileX, y);
++						anyUpdated = true;
++					}
++				}
++			}
++
++			if (anyUpdated || numLeft < 2 && numRight < 2 || Main.tile[x, y - 1].LiquidAmount <= 0)
++				tile.LiquidAmount = newAmount;
++ 		}
++ 	}
  
  	public static void StartPanic()
+ 	{
 @@ -970,6 +_,21 @@
  		Tile tile5 = Main.tile[x, y];
  		if ((tile.liquid > 0 && tile.liquidType() != thisLiquidType) || (tile2.liquid > 0 && tile2.liquidType() != thisLiquidType) || (tile3.liquid > 0 && tile3.liquidType() != thisLiquidType)) {

--- a/patches/tModLoader/Terraria/ModLoader/GlobalLiquid.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalLiquid.cs
@@ -1,0 +1,165 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Terraria.ModLoader;
+
+/// <summary>
+/// This class allows you to modify and use hooks for liquids, including vanilla items. Create an instance of an overriding class to use this.
+/// </summary>
+public abstract class GlobalLiquid : ModType
+{
+	protected sealed override void Register()
+	{
+		LiquidLoader.globalLiquids.Add(this);
+	}
+
+	public virtual void ModifyLight(int x, int y, int liquidType, ref float r, ref float g, ref float b) { }
+
+	/// <summary>
+	/// Called at the very start of Liquid.Update before liquid merges or liquid movement.
+	/// </summary>
+	/// <param name="x"></param>
+	/// <param name="y"></param>
+	/// <param name="liquidType"></param>
+	/// <param name="liquid"></param>
+	/// <param name="thisTile"></param>
+	/// <param name="left"></param>
+	/// <param name="right"></param>
+	/// <param name="up"></param>
+	/// <param name="down"></param>
+	public virtual void PreUpdate(int x, int y, int liquidType, Liquid liquid, Tile thisTile, Tile left, Tile right, Tile up, Tile down) { }
+
+	/// <summary>
+	/// Called just after liquid merge checks, and just before liquid movement checks.
+	/// </summary>
+	/// <param name="x"></param>
+	/// <param name="y"></param>
+	/// <param name="liquidType"></param>
+	/// <param name="liquid"></param>
+	/// <param name="thisTile"></param>
+	/// <param name="left"></param>
+	/// <param name="right"></param>
+	/// <param name="up"></param>
+	/// <param name="down"></param>
+	/// <returns></returns>
+	public virtual bool Update(int x, int y, int liquidType, Liquid liquid, Tile thisTile, Tile left, Tile right, Tile up, Tile down) => true;
+
+	/// <summary>
+	/// Called at the very end up Liquid.Update after merge and movement checks.
+	/// </summary>
+	/// <param name="x"></param>
+	/// <param name="y"></param>
+	/// <param name="liquidType"></param>
+	/// <param name="liquid"></param>
+	/// <param name="thisTile"></param>
+	/// <param name="left"></param>
+	/// <param name="right"></param>
+	/// <param name="up"></param>
+	/// <param name="down"></param>
+	public virtual void PostUpdate(int x, int y, int liquidType, Liquid liquid, Tile thisTile, Tile left, Tile right, Tile up, Tile down) { }
+
+	/// <summary>
+	/// Return false to prevent liquids from merging.  Return true by default.  This is called when checking if the liquid at Main.tile[x, y] is being updated.
+	/// If true is returned, the liquid at Main.tile[x2, y2] will be added to Main.liquid to be updated.
+	/// </summary>
+	/// <param name="x">x tile coordinate of the tile being checked</param>
+	/// <param name="y">y tile coordinate of the tile being checked</param>
+	/// <param name="tile">Tile at Main.tile[x, y]</param>
+	/// <param name="x2">x tile coordinate of the liquid trying to merge with this tile</param>
+	/// <param name="y2">y tile coordinate of the liquid trying to merge with this tile</param>
+	/// <param name="tile2">Tile at Main.tile[x2, y2]</param>
+	/// <returns></returns>
+	public virtual bool AllowMergeLiquids(int x, int y, Tile tile, int x2, int y2, Tile tile2) => true;
+
+	/// <summary>
+	/// Allows you to change the resulting tile created when liquids merge together.
+	/// </summary>
+	/// <param name="x">x tile coordinate of the tile being merged onto.</param>
+	/// <param name="y">y tile coordinate of the tile being merged onto.</param>
+	/// <param name="type">Liquid type at Main.tile[x, y]</param>
+	/// <param name="liquidNearby">Use liquidNearby[LiquidID] to check if that liquid is touching the tile being merged onto.</param>
+	/// <param name="liquidMergeTileType">The tile type being created by the merge at Main.tile[x, y].</param>
+	/// <param name="liquidMergeType">The liquid type that is being used to determine the created tile type.  (Changing only this will do nothing since the created tile has already been determined.)</param>
+	public virtual void GetLiquidMergeTypes(int x, int y, int type, bool[] liquidNearby, ref int liquidMergeTileType, ref int liquidMergeType, LiquidMerge liquidMerge) { }
+
+	/// <summary>
+	/// Called when a liquid merge is attempted and the total other liquids are less than 24 or the liquidMergeType is the same type as the liquidMerge.MergeTargetTile.LiquidType.
+	/// Return false to prevent the liquid above from being deleted and continue with the merge instead.  Return true by default.
+	/// </summary>
+	/// <param name="liquidMerge"></param>
+	/// <returns></returns>
+	public virtual bool ShouldDeleteLiquid(LiquidMerge liquidMerge) => true;
+
+	/// <summary>
+	/// Called after ShouldDeleteLiquid just before the liquid merge occurs.
+	/// Return true to prevent the merge from occurring.  Return true by default.
+	/// </summary>
+	/// <param name="liquidMerge"></param>
+	/// <returns></returns>
+	public virtual bool PreventMerge(LiquidMerge liquidMerge) => false;
+
+	/// <summary>
+	/// Called just after a merge occurs.  Tiles and liquids have already been updated.
+	/// </summary>
+	/// <param name="liquidMerge"></param>
+	/// <param name="consumedLiquids">The (type, amount) of liquids used in the merge.</param>
+	public virtual void OnMerge(LiquidMerge liquidMerge, Dictionary<int, int> consumedLiquids) { }
+
+	/// <summary>
+	/// x, y are the tile coordinates of the liquid that is trying to move.  
+	/// xMove, yMove are the tile coordinates of the tile the liquid is trying to move to.  
+	/// Return true to force the liquid to move.  
+	/// Return null for vanilla behavior (same as canMoveVanilla).  
+	/// Return false to prevent the liquid from moving.  
+	/// </summary>
+	/// <param name="x">x tile coordinate of the liquid</param>
+	/// <param name="y">y tile coordinate of the liquid</param>
+	/// <param name="xMove">x tile coordinate of the target being moved to</param>
+	/// <param name="yMove">y tile coordinate of the target being moved to</param>
+	/// <param name="canMoveLeftVanilla">Vanilla logic's determination of if the liquid should move or not.</param>
+	/// <returns></returns>
+	public virtual bool? CanMoveLeft(int x, int y, int xMove, int yMove, bool canMoveLeftVanilla) => null;
+
+	/// <summary>
+	/// x, y are the tile coordinates of the liquid that is trying to move.  
+	/// xMove, yMove are the tile coordinates of the tile the liquid is trying to move to.  
+	/// Return true to force the liquid to move.  
+	/// Return null for vanilla behavior (same as canMoveVanilla).  
+	/// Return false to prevent the liquid from moving.  
+	/// </summary>
+	/// <param name="x">x tile coordinate of the liquid</param>
+	/// <param name="y">y tile coordinate of the liquid</param>
+	/// <param name="xMove">x tile coordinate of the target being moved to</param>
+	/// <param name="yMove">y tile coordinate of the target being moved to</param>
+	/// <param name="canMoveRightVanilla">Vanilla logic's determination of if the liquid should move or not.</param>
+	/// <returns></returns>
+	public virtual bool? CanMoveRight(int x, int y, int xMove, int yMove, bool canMoveRightVanilla) => null;
+
+	/// <summary>
+	/// x, y are the tile coordinates of the liquid that is trying to move.  
+	/// xMove, yMove are the tile coordinates of the tile the liquid is trying to move to.  
+	/// Return true to force the liquid to move.  
+	/// Return null for vanilla behavior (same as canMoveVanilla).  
+	/// Return false to prevent the liquid from moving.  
+	/// </summary>
+	/// <param name="x">x tile coordinate of the liquid</param>
+	/// <param name="y">y tile coordinate of the liquid</param>
+	/// <param name="xMove">x tile coordinate of the target being moved to</param>
+	/// <param name="yMove">y tile coordinate of the target being moved to</param>
+	/// <param name="canMoveDownVanilla">Vanilla logic's determination of if the liquid should move or not.</param>
+	/// <returns></returns>
+	public virtual bool? CanMoveDown(int x, int y, int xMove, int yMove, bool canMoveDownVanilla) => null;
+
+	/// <summary>
+	/// Used to force or prevent liquids from being drawn at Main.tile[x, y].  This includes visual only liquid runoff from liquids.
+	/// This method is called on every tile being drawn, not just tiles with liquids or liquid runoffs.
+	/// </summary>
+	/// <param name="x">x tile coordinate of the tile being checked</param>
+	/// <param name="y">y tile coordinate of the tile being checked</param>
+	/// <param name="shouldDrawVanilla">Vanilla logic's determination of if liquids should be drawn at the location if applicable.</param>
+	/// <returns></returns>
+	public virtual bool? ShouldDrawLiquids(int x, int y, bool shouldDrawVanilla) => null;
+}

--- a/patches/tModLoader/Terraria/ModLoader/LiquidLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/LiquidLoader.cs
@@ -63,6 +63,15 @@ public static class LiquidLoader
 		Array.Resize(ref Main.PylonSystem._sceneMetrics._liquidCounts, nextLiquid);
 
 		//Hooks
+		ModLoader.BuildGlobalHook(ref HookModifyLight, globalLiquids, g => g.ModifyLight);
+		ModLoader.BuildGlobalHook(ref HookLiquidPreUpdate, globalLiquids, g => g.PreUpdate);
+		ModLoader.BuildGlobalHook(ref HookLiquidUpdate, globalLiquids, g => g.Update);
+		ModLoader.BuildGlobalHook(ref HookLiquidPostUpdate, globalLiquids, g => g.PostUpdate);
+		ModLoader.BuildGlobalHook(ref HookAllowMergeLiquids, globalLiquids, g => g.AllowMergeLiquids);
+		ModLoader.BuildGlobalHook(ref HookGetLiquidMergeTypes, globalLiquids, g => g.GetLiquidMergeTypes);
+		ModLoader.BuildGlobalHook(ref HookShouldDeleteLiquids, globalLiquids, g => g.ShouldDeleteLiquid);
+		ModLoader.BuildGlobalHook(ref HookPreventMerge, globalLiquids, g => g.PreventMerge);
+		ModLoader.BuildGlobalHook(ref HookOnMerge, globalLiquids, g => g.OnMerge);
 		ModLoader.BuildGlobalHook(ref HookCanMoveLeft, globalLiquids, g => g.CanMoveLeft);
 		ModLoader.BuildGlobalHook(ref HookCanMoveRight, globalLiquids, g => g.CanMoveRight);
 		ModLoader.BuildGlobalHook(ref HookCanMoveDown, globalLiquids, g => g.CanMoveDown);
@@ -80,24 +89,140 @@ public static class LiquidLoader
 		liquids.Clear();
 	}
 
-	public static void ModifyLight(int type, int i, int j, ref float r, ref float g, ref float b)
+	private delegate void DelegateModifyLight(int x, int y, int liquidType, ref float r, ref float g, ref float b);
+	private static DelegateModifyLight[] HookModifyLight;
+	public static void ModifyLight(int x, int y, int liquidType, ref float r, ref float g, ref float b)
 	{
-		GetLiquid(type)?.ModifyLight(i, j, ref r, ref g, ref b);
+		GetLiquid(liquidType)?.ModifyLight(x, y, ref r, ref g, ref b);
+
+		foreach (var hook in HookModifyLight) {
+			hook(x, y, liquidType, ref r, ref g, ref b);
+		}
 	}
 
-	public static void PreUpdate(int type, int x, int y)
+	private delegate void DelegateLiquidPreUpdate(int x, int y, int liquidType, Liquid liquid, Tile thisTile, Tile left, Tile right, Tile up, Tile down);
+	private static DelegateLiquidPreUpdate[] HookLiquidPreUpdate;
+	public static void PreUpdate(int x, int y, int liquidType, Liquid liquid, Tile thisTile, Tile left, Tile right, Tile up, Tile down)
 	{
-		GetLiquid(type)?.PreUpdate(x, y);
+		GetLiquid(liquidType)?.PreUpdate(x, y, liquid, thisTile, left, right, up, down);
+
+		foreach (var hook in HookLiquidPreUpdate) {
+			hook(x, y, liquidType, liquid, thisTile, left, right, up, down);
+		}
 	}
 
-	public static bool Update(int type, Liquid liquid, int x, int y, Tile left, Tile right, Tile up, Tile down)
+	private delegate bool DelegateLiquidUpdate(int x, int y, int liquidType, Liquid liquid, Tile thisTile, Tile left, Tile right, Tile up, Tile down);
+	private static DelegateLiquidUpdate[] HookLiquidUpdate;
+	public static bool Update(int x, int y, int liquidType, Liquid liquid, Tile thisTile, Tile left, Tile right, Tile up, Tile down)
 	{
-		return GetLiquid(type)?.Update(liquid, x, y, left, right, up, down) ?? true;
+		bool result = GetLiquid(liquidType)?.Update(x, y, liquid, thisTile, left, right, up, down) ?? true;
+
+		foreach (var hook in HookLiquidUpdate) {
+			if (!hook(x, y, liquidType, liquid, thisTile, left, right, up, down))
+				result = false;
+		}
+
+		return result;
 	}
 
-	public static void Merge(int type, bool[] liquidNearby, ref int liquidMergeTileType, ref int liquidMergeType)
+	private delegate void DelegateLiquidPostUpdate(int x, int y, int liquidType, Liquid liquid, Tile thisTile, Tile left, Tile right, Tile up, Tile down);
+	private static DelegateLiquidPostUpdate[] HookLiquidPostUpdate;
+	public static void PostUpdate(int x, int y, int liquidType, Liquid liquid, Tile thisTile, Tile left, Tile right, Tile up, Tile down)
 	{
-		GetLiquid(type)?.Merge(type, liquidNearby, ref liquidMergeTileType, ref liquidMergeType);
+		GetLiquid(liquidType)?.PostUpdate(x, y, liquid, thisTile, left, right, up, down);
+
+		foreach (var hook in HookLiquidPostUpdate) {
+			hook(x, y, liquidType, liquid, thisTile, left, right, up, down);
+		}
+	}
+
+	private delegate bool DelegateAllowMergeLiquids(int x, int y, Tile tile, int x2, int y2, Tile tile2);
+	private static DelegateAllowMergeLiquids[] HookAllowMergeLiquids;
+	public static bool AllowMergeLiquids(int x, int y, Tile tile, int x2, int y2, Tile tile2)
+	{
+		//AllowMergeLiquids is only called when there is a liquid at Main.tile[x, y] and Main.tile[x2, y2] and they will always be different types.
+		if (GetLiquid(tile.LiquidType)?.AllowMergeLiquids(x, y, tile, x2, y2, tile2) == false)
+			return false;
+
+		if (GetLiquid(tile2.LiquidType)?.AllowMergeLiquids(x, y, tile, x2, y2, tile2) == false)
+			return false;
+
+		foreach (var hook in HookAllowMergeLiquids) {
+			bool? shouldMerge = hook(x, y, tile, x2, y2, tile2);
+			if (shouldMerge.HasValue) {
+				if (!shouldMerge.Value)
+					return false;
+			}
+		}
+
+		return true;
+	}
+
+	private delegate void DelegateGetLiquidMergeTypes(int x, int y, int type, bool[] liquidNearby, ref int liquidMergeTileType, ref int liquidMergeType, LiquidMerge liquidMerge);
+	private static DelegateGetLiquidMergeTypes[] HookGetLiquidMergeTypes;
+	public static void GetLiquidMergeTypes(int x, int y, int liquidType, bool[] liquidsNearby, ref int liquidMergeTileType, ref int liquidMergeType, LiquidMerge liquidMerge)
+	{
+		SortedSet<int> liquidsToCheck = new() { liquidType };
+		for (int i = 0; i < liquidsNearby.Length; i++) {
+			if (liquidsNearby[i])
+				liquidsToCheck.Add(i);
+		}
+
+		foreach (int liquidToCheck in liquidsToCheck) {
+			GetLiquid(liquidToCheck)?.GetLiquidMergeTypes(x, y, liquidType, liquidsNearby, ref liquidMergeTileType, ref liquidMergeType, liquidMerge);
+		}
+
+		foreach (var hook in HookGetLiquidMergeTypes) {
+			hook(x, y, liquidType, liquidsNearby, ref liquidMergeTileType, ref liquidMergeType, liquidMerge);
+		}
+	}
+
+	private delegate bool DelegateShouldDeleteLiquids(LiquidMerge liquidMerge);
+	private static DelegateShouldDeleteLiquids[] HookShouldDeleteLiquids;
+	public static bool ShouldDeleteLiquid(LiquidMerge liquidMerge)
+	{
+		SortedSet<int> liquidsToCheck = new();
+		foreach (LiquidMergeIngredient liquidMergeIngredient in liquidMerge.LiquidMergeIngredients) {
+			liquidsToCheck.Add(liquidMergeIngredient.LiquidType);
+		}
+
+		foreach (int liquidToCheck in liquidsToCheck) {
+			if (GetLiquid(liquidToCheck)?.ShouldDeleteLiquid(liquidMerge) == false)
+				return false;
+		}
+
+		foreach (var hook in HookShouldDeleteLiquids) {
+			if (!hook(liquidMerge))
+				return false;
+		}
+
+		return true;
+	}
+
+	private delegate bool DelegatePreventMerge(LiquidMerge liquidMerge);
+	private static DelegatePreventMerge[] HookPreventMerge;
+	public static bool PreventMerge(LiquidMerge liquidMerge)
+	{
+		if (GetLiquid(liquidMerge.MergeTargetTile.LiquidType)?.PreventMerge(liquidMerge) ?? false)
+			return true;
+
+		foreach (var hook in HookPreventMerge) {
+			if (hook(liquidMerge))
+				return true;
+		}
+
+		return false;
+	}
+
+	private delegate void DelegateOnMerge(LiquidMerge liquidMerge, Dictionary<int, int> consumedLiquids);
+	private static DelegateOnMerge[] HookOnMerge;
+	public static void OnMerge(LiquidMerge liquidMerge, Dictionary<int, int> consumedLiquids)
+	{
+		GetLiquid(liquidMerge.MergeTargetTile.LiquidType)?.OnMerge(liquidMerge, consumedLiquids);
+
+		foreach (var hook in HookOnMerge) {
+			hook(liquidMerge, consumedLiquids);
+		}
 	}
 
 	static LiquidLoader()
@@ -142,7 +267,7 @@ public static class LiquidLoader
 
 	private delegate bool? DelegateCanMoveRight(int x, int y, int xMove, int yMove, bool canMoveRightVanilla);
 	private static DelegateCanMove[] HookCanMoveRight;
-	public static bool? CanMoveRight(int x, int y, int xMove, int yMove, bool canMoveRightVanilla)
+	public static bool CanMoveRight(int x, int y, int xMove, int yMove, bool canMoveRightVanilla)
 	{
 		bool? result = null;
 

--- a/patches/tModLoader/Terraria/ModLoader/ModLiquid.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModLiquid.cs
@@ -108,19 +108,70 @@ public abstract class ModLiquid : ModBlockType
 		}
 	}
 
+	/// <summary>
+	/// Called at the very start of Liquid.Update before liquid merges or liquid movement.
+	/// </summary>
+	/// <param name="x"></param>
+	/// <param name="y"></param>
+	/// <param name="liquid"></param>
+	/// <param name="thisTile"></param>
+	/// <param name="left"></param>
+	/// <param name="right"></param>
+	/// <param name="up"></param>
+	/// <param name="down"></param>
+	public virtual void PreUpdate(int x, int y, Liquid liquid, Tile thisTile, Tile left, Tile right, Tile up, Tile down) { }
 
-	public virtual void PreUpdate(int x, int y)
-	{
-		
-	}
+	/// <summary>
+	/// Called just after liquid merge checks, and just before liquid movement checks.
+	/// </summary>
+	/// <param name="x"></param>
+	/// <param name="y"></param>
+	/// <param name="liquid"></param>
+	/// <param name="thisTile"></param>
+	/// <param name="left"></param>
+	/// <param name="right"></param>
+	/// <param name="up"></param>
+	/// <param name="down"></param>
+	/// <returns></returns>
+	public virtual bool Update(int x, int y, Liquid liquid, Tile thisTile, Tile left, Tile right, Tile up, Tile down) => true;
 
-	public virtual bool Update(Liquid liquid, int x, int y, Tile left, Tile right, Tile up, Tile down)
-	{
-		return true;
-	}
+	/// <summary>
+	/// Called at the very end up Liquid.Update after merge and movement checks.
+	/// </summary>
+	/// <param name="x"></param>
+	/// <param name="y"></param>
+	/// <param name="liquid"></param>
+	/// <param name="thisTile"></param>
+	/// <param name="left"></param>
+	/// <param name="right"></param>
+	/// <param name="up"></param>
+	/// <param name="down"></param>
+	public virtual void PostUpdate(int x, int y, Liquid liquid, Tile thisTile, Tile left, Tile right, Tile up, Tile down) { }
 
-	public virtual void Merge(int otherLiquid, bool[] liquidNearby, ref int liquidMergeTileType, ref int liquidMergeType)
-	{
+	/// <summary>
+	/// Return false to prevent liquids from merging.  Return true by default.
+	/// </summary>
+	/// <param name="x"></param>
+	/// <param name="y"></param>
+	/// <param name="tile"></param>
+	/// <param name="x2"></param>
+	/// <param name="y2"></param>
+	/// <param name="tile2"></param>
+	/// <returns></returns>
+	public virtual bool AllowMergeLiquids(int x, int y, Tile tile, int x2, int y2, Tile tile2) => true;
 
-	}
+	/// <summary>
+	/// Allows you to change the resulting tile created when liquids merge together.
+	/// </summary>
+	/// <param name="x">x tile coordinate of the tile being merged onto.</param>
+	/// <param name="y">y tile coordinate of the tile being merged onto.</param>
+	/// <param name="type">Liquid type at Main.tile[x, y]</param>
+	/// <param name="liquidNearby">Use liquidNearby[LiquidID] to check if that liquid is touching the tile being merged onto.</param>
+	/// <param name="liquidMergeTileType">The tile type being created by the merge at Main.tile[x, y].</param>
+	/// <param name="liquidMergeType">The liquid type that is being used to determine the created tile type.  (Changing only this will do nothing since the created tile has already been determined.)</param>
+	public virtual void GetLiquidMergeTypes(int x, int y, int otherLiquid, bool[] liquidNearby, ref int liquidMergeTileType, ref int liquidMergeType, LiquidMerge liquidMerge) { }
+
+	public virtual void OnMerge(LiquidMerge liquidMerge, Dictionary<int, int> consumedLiquids) { }
+	public virtual bool PreventMerge(LiquidMerge liquidMerge) => false;
+	public virtual bool ShouldDeleteLiquid(LiquidMerge liquidMerge) => false;
 }

--- a/patches/tModLoader/Terraria/WorldGen.cs.patch
+++ b/patches/tModLoader/Terraria/WorldGen.cs.patch
@@ -26,21 +26,25 @@
  		if (tile.nactive() && Main.tileSolid[tile.type] && !Main.tileSolidTop[tile.type])
  			return false;
  
-@@ -1077,7 +_,13 @@
- 		bool honeyNearby = b == 2;
- 		bool shimmerNearby = b == 3;
- 		int liquidMergeType = 0;
+@@ -1071,6 +_,10 @@
+ 			return true;
+ 		}
+ 
++		LiquidMerge liquidMerge = new(x, y, liquidType, amount);
++		liquidMerge.TryPlaceMerge();
 +
-+		bool[] liquidNearby = new bool[LiquidLoader.LiquidCount];
-+
-+		liquidNearby[b] = true;
-+
--		Liquid.GetLiquidMergeTypes(liquidType, out liquidMergeTileType, out liquidMergeType, waterNearby, lavaNearby, honeyNearby, shimmerNearby);
-+		// Liquid.GetLiquidMergeTypes(thisLiquidType, out liquidMergeTileType, out liquidMergeType, waterNearby, lavaNearby, honeyNearby, shimmerNearby);
-+		Liquid.GetLiquidMergeTypes(b, out liquidMergeTileType, out liquidMergeType, liquidNearby);
- 		if (liquidMergeTileType != 0) {
- 			tile.liquid = 0;
- 			tile.liquidType(0);
++		/*
+ 		int liquidMergeTileType = 0;
+ 		bool waterNearby = b == 0;
+ 		bool lavaNearby = b == 1;
+@@ -1088,6 +_,7 @@
+ 
+ 			return true;
+ 		}
++		*/
+ 
+ 		return false;
+ 	}
 @@ -1284,7 +_,7 @@
  			}
  		}


### PR DESCRIPTION
Liquid.cs, LiquidLoader.cs, LiquidRender.cs, GlobalLiquid.cs:
Replaced vanilla horizontal liquid movement with for loops to make the code much easier to work with and create hooks.  Added hooks for CanMoveLeft, CanMoveRight, CanMoveDown, and ShouldDrawLiquids.  ShouldDrawLiquids only affects the visual only runoff drawn prior to normal liquid movement.  If liquid movement is prevented, it is likely a modder wouldn't want this to be drawn (see ExampleGlobalLiquid.)

ExampleGlobalLiquid.cs:
Implements the new hooks using ExampleBlocks to prevent liquids from moving and drawing the runoff.

I need to test these all one more time before they are ready to be merged.